### PR TITLE
Clientside mod remote_player_waypoints_for_xaero

### DIFF
--- a/modrinth.index.json
+++ b/modrinth.index.json
@@ -582,7 +582,7 @@
         "sha1": "fd6f83d15075acfb9388100a82777163cfd0ee60"
       },
       "env": {
-        "server": "required",
+        "server": "unsupported",
         "client": "required"
       },
       "downloads": [


### PR DESCRIPTION
Fixes a crash on the server where this mod will fail to load.

Relates #1 